### PR TITLE
feat: add admin endpoints for clubs and fields

### DIFF
--- a/backend/app/Http/Controllers/Api/ClubController.php
+++ b/backend/app/Http/Controllers/Api/ClubController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ClubRequest;
+use App\Models\Club;
+use Illuminate\Http\Request;
+
+class ClubController extends Controller
+{
+    public function index()
+    {
+        return Club::paginate();
+    }
+
+    public function store(ClubRequest $request)
+    {
+        $club = Club::create([
+            'user_id' => $request->user()->id,
+            'name' => $request->name,
+            'address' => $request->address,
+            'lat' => $request->lat,
+            'lng' => $request->lng,
+        ]);
+
+        return response()->json($club, 201);
+    }
+
+    public function update(ClubRequest $request, Club $club)
+    {
+        $club->update($request->validated());
+
+        return response()->json($club);
+    }
+
+    public function destroy(Club $club)
+    {
+        $club->delete();
+
+        return response()->noContent();
+    }
+}
+

--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\FieldRequest;
 use App\Models\Field;
 use Illuminate\Http\Request;
 
@@ -26,4 +27,26 @@ class FieldController extends Controller
 
         return $query->paginate();
     }
+
+    public function store(FieldRequest $request)
+    {
+        $field = Field::create($request->validated());
+
+        return response()->json($field, 201);
+    }
+
+    public function update(FieldRequest $request, Field $field)
+    {
+        $field->update($request->validated());
+
+        return response()->json($field);
+    }
+
+    public function destroy(Field $field)
+    {
+        $field->delete();
+
+        return response()->noContent();
+    }
 }
+

--- a/backend/app/Http/Requests/ClubRequest.php
+++ b/backend/app/Http/Requests/ClubRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ClubRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'address' => 'nullable|string|max:255',
+            'lat' => 'nullable|numeric',
+            'lng' => 'nullable|numeric',
+        ];
+    }
+}
+

--- a/backend/app/Http/Requests/FieldRequest.php
+++ b/backend/app/Http/Requests/FieldRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FieldRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'club_id' => 'required|exists:clubs,id',
+            'name' => 'required|string|max:255',
+            'sport' => 'required|string|max:255',
+            'surface' => 'nullable|string|max:255',
+            'indoor' => 'boolean',
+            'lighting' => 'boolean',
+            'price_per_hour' => 'required|numeric',
+        ];
+    }
+}
+

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\FieldController;
 use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\PaymentWebhookController;
+use App\Http\Controllers\Api\ClubController;
 
 Route::prefix('v1')->group(function () {
     Route::post('auth/register', [AuthController::class, 'register']);
@@ -15,6 +16,17 @@ Route::prefix('v1')->group(function () {
         Route::post('auth/logout', [AuthController::class, 'logout']);
 
         Route::get('fields', [FieldController::class, 'index']);
+
+        Route::middleware('role:admin,superadmin')->group(function () {
+            Route::get('clubs', [ClubController::class, 'index']);
+            Route::post('clubs', [ClubController::class, 'store']);
+            Route::put('clubs/{club}', [ClubController::class, 'update']);
+            Route::delete('clubs/{club}', [ClubController::class, 'destroy']);
+
+            Route::post('fields', [FieldController::class, 'store']);
+            Route::put('fields/{field}', [FieldController::class, 'update']);
+            Route::delete('fields/{field}', [FieldController::class, 'destroy']);
+        });
 
         Route::get('reservations', [ReservationController::class, 'index']);
         Route::post('reservations', [ReservationController::class, 'store']);

--- a/backend/tests/Feature/Api/ClubTest.php
+++ b/backend/tests/Feature/Api/ClubTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClubTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_club(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/clubs', [
+                'name' => 'Club Test',
+                'address' => 'Street 123',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['name' => 'Club Test']);
+    }
+}
+

--- a/backend/tests/Feature/Api/FieldTest.php
+++ b/backend/tests/Feature/Api/FieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Api;
 
+use App\Models\Club;
+use App\Models\Field;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -22,4 +24,82 @@ class FieldTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure(['data']);
     }
+
+    public function test_admin_can_create_field(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/fields', [
+                'club_id' => $club->id,
+                'name' => 'Cancha 2',
+                'sport' => 'futbol',
+                'price_per_hour' => 100,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['name' => 'Cancha 2']);
+    }
+
+    public function test_admin_can_update_field(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Cancha 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/fields/' . $field->id, [
+                'club_id' => $club->id,
+                'name' => 'Cancha 1 updated',
+                'sport' => 'futbol',
+                'price_per_hour' => 150,
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'Cancha 1 updated']);
+    }
+
+    public function test_admin_can_delete_field(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Cancha 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->deleteJson('/api/v1/fields/' . $field->id);
+
+        $response->assertStatus(204);
+    }
 }
+


### PR DESCRIPTION
## Summary
- add ClubController and CRUD routes guarded by role middleware
- extend FieldController with create/update/delete logic
- validate input via ClubRequest and FieldRequest
- cover admin club/field management with feature tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a8df7b7ef48320a9fb3439a18b0f3f