### PR TITLE
Integrate Mercado Pago checkout and webhook handling

### DIFF
--- a/backend/app/Http/Controllers/Api/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/PaymentController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+use App\Models\Payment;
+use Illuminate\Http\Request;
+use MercadoPago\MercadoPagoConfig;
+use MercadoPago\Client\Preference\PreferenceClient;
+
+class PaymentController extends Controller
+{
+    public function checkout(Request $request)
+    {
+        $data = $request->validate([
+            'reservation_id' => ['required', 'exists:reservations,id'],
+        ]);
+
+        $reservation = Reservation::findOrFail($data['reservation_id']);
+
+        MercadoPagoConfig::setAccessToken(config('services.mercadopago.token'));
+        $client = new PreferenceClient();
+
+        $preference = $client->create([
+            'items' => [
+                [
+                    'title' => 'Reservation ' . $reservation->id,
+                    'quantity' => 1,
+                    'unit_price' => (float) $reservation->total_price,
+                ],
+            ],
+            'metadata' => [
+                'reservation_id' => $reservation->id,
+            ],
+        ]);
+
+        Payment::create([
+            'reservation_id' => $reservation->id,
+            'provider' => 'mercadopago',
+            'status' => 'pending',
+            'amount' => $reservation->total_price,
+            'payload' => [],
+        ]);
+
+        return response()->json([
+            'preference_id' => $preference->id ?? null,
+            'init_point' => $preference->init_point ?? null,
+        ], 201);
+    }
+}

--- a/backend/app/Http/Controllers/Api/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/Api/PaymentWebhookController.php
@@ -4,19 +4,35 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Payment;
+use App\Models\Reservation;
 use Illuminate\Http\Request;
 
 class PaymentWebhookController extends Controller
 {
     public function __invoke(Request $request)
     {
-        Payment::create([
-            'reservation_id' => $request->input('reservation_id'),
-            'status' => $request->input('status', 'paid'),
-            'amount' => $request->input('amount', 0),
-            'provider' => 'mercadopago',
-            'payload' => $request->all(),
-        ]);
+        $secret = config('services.mercadopago.webhook_secret');
+        $signature = $request->header('x-signature');
+        $expected = hash_hmac('sha256', $request->getContent(), $secret ?? '');
+
+        if (!$signature || !hash_equals($expected, $signature)) {
+            return response()->json(['message' => 'Invalid signature'], 401);
+        }
+
+        $reservation = Reservation::findOrFail($request->input('reservation_id'));
+        $status = $request->input('status', 'paid');
+
+        $reservation->update(['status' => $status]);
+
+        Payment::updateOrCreate(
+            ['reservation_id' => $reservation->id],
+            [
+                'status' => $status,
+                'amount' => $request->input('amount', 0),
+                'provider' => 'mercadopago',
+                'payload' => $request->all(),
+            ]
+        );
 
         return response()->json(['received' => true]);
     }

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -9,7 +9,8 @@
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.2",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "mercadopago/dx-php": "^3.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f387a0734f3bf879214e4aa2fca6e2f",
+    "content-hash": "15cd0518b6cf4d1a0960fe04798f82ea",
     "packages": [
         {
             "name": "brick/math",
@@ -2070,6 +2070,45 @@
                 }
             ],
             "time": "2024-12-08T08:18:47+00:00"
+        },
+        {
+            "name": "mercadopago/dx-php",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mercadopago/sdk-php.git",
+                "reference": "657be1bf17b08b3c887891245825e56111006883"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mercadopago/sdk-php/zipball/657be1bf17b08b3c887891245825e56111006883",
+                "reference": "657be1bf17b08b3c887891245825e56111006883",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.22",
+                "phpunit/phpunit": "^10.2",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MercadoPago\\": "src/MercadoPago"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Mercado Pago PHP SDK",
+            "homepage": "https://github.com/mercadopago/sdk-php",
+            "support": {
+                "source": "https://github.com/mercadopago/sdk-php/tree/3.5.1"
+            },
+            "time": "2025-06-09T13:08:57+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -35,4 +35,10 @@ return [
         ],
     ],
 
+    'mercadopago' => [
+        'token' => env('MERCADOPAGO_ACCESS_TOKEN'),
+        'public_key' => env('MERCADOPAGO_PUBLIC_KEY'),
+        'webhook_secret' => env('MERCADOPAGO_WEBHOOK_SECRET'),
+    ],
+
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\FieldController;
 use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\PaymentWebhookController;
 use App\Http\Controllers\Api\ClubController;
+use App\Http\Controllers\Api\PaymentController;
 
 Route::prefix('v1')->group(function () {
     Route::post('auth/register', [AuthController::class, 'register']);
@@ -33,6 +34,8 @@ Route::prefix('v1')->group(function () {
         Route::put('reservations/{reservation}', [ReservationController::class, 'update']);
         Route::post('reservations/{reservation}/waitlist', [ReservationController::class, 'waitlist']);
         Route::delete('reservations/{reservation}', [ReservationController::class, 'destroy']);
+
+        Route::post('payments/checkout', [PaymentController::class, 'checkout']);
     });
 
     Route::post('payments/webhook', PaymentWebhookController::class);

--- a/backend/tests/Feature/Api/PaymentWebhookTest.php
+++ b/backend/tests/Feature/Api/PaymentWebhookTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Club;
+use App\Models\Field;
+use App\Models\Reservation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PaymentWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @dataProvider statusProvider
+     */
+    public function test_webhook_updates_reservation_status(string $status): void
+    {
+        config()->set('services.mercadopago.webhook_secret', 'secret');
+
+        $user = User::factory()->create();
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club',
+            'address' => 'Street',
+        ]);
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Field',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+        $reservation = Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        $payload = [
+            'reservation_id' => $reservation->id,
+            'status' => $status,
+            'amount' => 100,
+        ];
+        $signature = hash_hmac('sha256', json_encode($payload), 'secret');
+
+        $this->withHeader('X-Signature', $signature)
+            ->postJson('/api/v1/payments/webhook', $payload)
+            ->assertOk();
+
+        $reservation->refresh();
+        $this->assertSame($status, $reservation->status);
+        $this->assertDatabaseHas('payments', [
+            'reservation_id' => $reservation->id,
+            'status' => $status,
+        ]);
+    }
+
+    public static function statusProvider(): array
+    {
+        return [
+            ['pending'],
+            ['paid'],
+            ['failed'],
+        ];
+    }
+
+    public function test_invalid_signature_returns_unauthorized(): void
+    {
+        config()->set('services.mercadopago.webhook_secret', 'secret');
+
+        $user = User::factory()->create();
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club',
+            'address' => 'Street',
+        ]);
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Field',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+        $reservation = Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        $payload = [
+            'reservation_id' => $reservation->id,
+            'status' => 'paid',
+            'amount' => 100,
+        ];
+
+        $this->withHeader('X-Signature', 'invalid')
+            ->postJson('/api/v1/payments/webhook', $payload)
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary
- add Mercado Pago SDK configuration
- implement checkout and webhook controllers for payments
- cover payment webhook with feature tests

## Testing
- `composer update mercadopago/dx-php --no-ansi`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a8fd1be8888320b6b468e4a0f8196a