### PR TITLE
Add tournaments with team registration

### DIFF
--- a/backend/app/Http/Controllers/Api/TournamentController.php
+++ b/backend/app/Http/Controllers/Api/TournamentController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Registration;
+use App\Models\Team;
+use App\Models\Tournament;
+use Illuminate\Http\Request;
+
+class TournamentController extends Controller
+{
+    public function index()
+    {
+        return Tournament::paginate();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+            'location' => ['nullable', 'string'],
+        ]);
+
+        $tournament = Tournament::create($data);
+
+        return response()->json($tournament, 201);
+    }
+
+    public function show(Tournament $tournament)
+    {
+        return $tournament->load('teams');
+    }
+
+    public function update(Request $request, Tournament $tournament)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+            'location' => ['nullable', 'string'],
+        ]);
+
+        $tournament->update($data);
+
+        return response()->json($tournament);
+    }
+
+    public function destroy(Tournament $tournament)
+    {
+        $tournament->delete();
+
+        return response()->noContent();
+    }
+
+    public function register(Request $request, Tournament $tournament)
+    {
+        $data = $request->validate([
+            'team_name' => ['required', 'string'],
+        ]);
+
+        $team = Team::create(['name' => $data['team_name']]);
+
+        $registration = Registration::create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+        ]);
+
+        return response()->json($registration->load('team', 'tournament'), 201);
+    }
+}

--- a/backend/app/Models/Registration.php
+++ b/backend/app/Models/Registration.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Registration extends Model
+{
+    protected $fillable = [
+        'tournament_id',
+        'team_id',
+    ];
+
+    public function tournament(): BelongsTo
+    {
+        return $this->belongsTo(Tournament::class);
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Team extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+
+    public function registrations(): HasMany
+    {
+        return $this->hasMany(Registration::class);
+    }
+
+    public function tournaments(): BelongsToMany
+    {
+        return $this->belongsToMany(Tournament::class, 'registrations');
+    }
+}

--- a/backend/app/Models/Tournament.php
+++ b/backend/app/Models/Tournament.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Tournament extends Model
+{
+    protected $fillable = [
+        'name',
+        'start_date',
+        'end_date',
+        'location',
+    ];
+
+    public function registrations(): HasMany
+    {
+        return $this->hasMany(Registration::class);
+    }
+
+    public function teams(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class, 'registrations');
+    }
+}

--- a/backend/database/migrations/2025_08_22_184311_create_tournaments_table.php
+++ b/backend/database/migrations/2025_08_22_184311_create_tournaments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tournaments', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->string('location')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tournaments');
+    }
+};

--- a/backend/database/migrations/2025_08_22_184312_create_teams_table.php
+++ b/backend/database/migrations/2025_08_22_184312_create_teams_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/backend/database/migrations/2025_08_22_184313_create_registrations_table.php
+++ b/backend/database/migrations/2025_08_22_184313_create_registrations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('registrations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tournament_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['tournament_id', 'team_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('registrations');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -36,5 +36,11 @@ class DatabaseSeeder extends Seeder
             'surface' => 'cesped',
             'price_per_hour' => 100,
         ]);
+
+        $this->call([
+            TournamentSeeder::class,
+            TeamSeeder::class,
+            RegistrationSeeder::class,
+        ]);
     }
 }

--- a/backend/database/seeders/RegistrationSeeder.php
+++ b/backend/database/seeders/RegistrationSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Registration;
+use App\Models\Team;
+use App\Models\Tournament;
+use Illuminate\Database\Seeder;
+
+class RegistrationSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $tournament = Tournament::first();
+        $team = Team::first();
+
+        if ($tournament && $team) {
+            Registration::create([
+                'tournament_id' => $tournament->id,
+                'team_id' => $team->id,
+            ]);
+        }
+    }
+}

--- a/backend/database/seeders/TeamSeeder.php
+++ b/backend/database/seeders/TeamSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Team;
+use Illuminate\Database\Seeder;
+
+class TeamSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Team::create([
+            'name' => 'The Eagles',
+        ]);
+    }
+}

--- a/backend/database/seeders/TournamentSeeder.php
+++ b/backend/database/seeders/TournamentSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tournament;
+use Illuminate\Database\Seeder;
+
+class TournamentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Tournament::create([
+            'name' => 'Summer Cup',
+            'start_date' => now()->addMonth()->toDateString(),
+            'end_date' => now()->addMonths(2)->toDateString(),
+            'location' => 'Main Stadium',
+        ]);
+    }
+}

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -30,6 +30,53 @@ paths:
       summary: List fields
       responses:
         '200': {description: OK}
+  /tournaments:
+    get:
+      summary: List tournaments
+      responses:
+        '200': {description: OK}
+    post:
+      summary: Create tournament
+      responses:
+        '201': {description: Created}
+  /tournaments/{id}:
+    get:
+      summary: Show tournament
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200': {description: OK}
+    put:
+      summary: Update tournament
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200': {description: OK}
+    delete:
+      summary: Delete tournament
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '204': {description: No Content}
+  /tournaments/{id}/register:
+    post:
+      summary: Register team to tournament
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '201': {description: Created}
   /reservations:
     get:
       summary: List user reservations

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\PaymentWebhookController;
 use App\Http\Controllers\Api\ClubController;
 use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\TournamentController;
 
 Route::prefix('v1')->group(function () {
     Route::post('auth/register', [AuthController::class, 'register']);
@@ -18,6 +19,10 @@ Route::prefix('v1')->group(function () {
 
         Route::get('fields', [FieldController::class, 'index']);
 
+        Route::get('tournaments', [TournamentController::class, 'index']);
+        Route::get('tournaments/{tournament}', [TournamentController::class, 'show']);
+        Route::post('tournaments/{tournament}/register', [TournamentController::class, 'register']);
+
         Route::middleware('role:admin,superadmin')->group(function () {
             Route::get('clubs', [ClubController::class, 'index']);
             Route::post('clubs', [ClubController::class, 'store']);
@@ -27,6 +32,10 @@ Route::prefix('v1')->group(function () {
             Route::post('fields', [FieldController::class, 'store']);
             Route::put('fields/{field}', [FieldController::class, 'update']);
             Route::delete('fields/{field}', [FieldController::class, 'destroy']);
+
+            Route::post('tournaments', [TournamentController::class, 'store']);
+            Route::put('tournaments/{tournament}', [TournamentController::class, 'update']);
+            Route::delete('tournaments/{tournament}', [TournamentController::class, 'destroy']);
         });
 
         Route::get('reservations', [ReservationController::class, 'index']);

--- a/backend/tests/Feature/Api/TournamentTest.php
+++ b/backend/tests/Feature/Api/TournamentTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Tournament;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TournamentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_tournaments(): void
+    {
+        $this->seed();
+        $user = User::first();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/tournaments');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_admin_can_create_tournament(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/tournaments', [
+                'name' => 'Winter Cup',
+                'start_date' => now()->toDateString(),
+                'end_date' => now()->addWeek()->toDateString(),
+                'location' => 'City Park',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['name' => 'Winter Cup']);
+    }
+
+    public function test_admin_can_update_tournament(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $tournament = Tournament::create([
+            'name' => 'Spring Cup',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addWeek()->toDateString(),
+            'location' => 'Old Field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/tournaments/' . $tournament->id, [
+                'name' => 'Spring Cup Updated',
+                'start_date' => now()->toDateString(),
+                'end_date' => now()->addWeek()->toDateString(),
+                'location' => 'New Field',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'Spring Cup Updated']);
+    }
+
+    public function test_admin_can_delete_tournament(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $token = $user->createToken('test')->plainTextToken;
+
+        $tournament = Tournament::create([
+            'name' => 'Autumn Cup',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addWeek()->toDateString(),
+            'location' => 'Some Field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->deleteJson('/api/v1/tournaments/' . $tournament->id);
+
+        $response->assertStatus(204);
+    }
+
+    public function test_can_register_team_in_tournament(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $tournament = Tournament::create([
+            'name' => 'Registration Cup',
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addWeek()->toDateString(),
+            'location' => 'Main Field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/tournaments/' . $tournament->id . '/register', [
+                'team_name' => 'Champions',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['team_id' => 1]);
+    }
+}


### PR DESCRIPTION
## Summary
- add models and migrations for tournaments, teams and registrations
- implement TournamentController with CRUD and team registration endpoints
- document tournament routes and seed sample data
- cover tournament flow with feature tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68adcae9a1988320af60a0a5a4dfb360