### PR TITLE
Add nearby field weather endpoint with Redis caching

### DIFF
--- a/backend/app/Http/Controllers/Api/NearbyFieldController.php
+++ b/backend/app/Http/Controllers/Api/NearbyFieldController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Field;
+use App\Services\WeatherService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class NearbyFieldController extends Controller
+{
+    public function __invoke(Request $request, WeatherService $weather)
+    {
+        $lat = (float) $request->query('lat');
+        $lng = (float) $request->query('lng');
+
+        $cacheKey = sprintf('nearby_fields_%s_%s', $lat, $lng);
+
+        $fields = Cache::store('redis')->remember($cacheKey, 60, function () use ($lat, $lng, $weather) {
+            return Field::with('club')->get()
+                ->filter(function ($field) use ($lat, $lng) {
+                    if (!$field->club) {
+                        return false;
+                    }
+                    $distance = $this->distance($lat, $lng, $field->club->lat, $field->club->lng);
+                    return $distance <= 50; // kilometers
+                })
+                ->map(function ($field) use ($weather) {
+                    return [
+                        'id' => $field->id,
+                        'name' => $field->name,
+                        'sport' => $field->sport,
+                        'price_per_hour' => $field->price_per_hour,
+                        'club' => [
+                            'id' => $field->club->id,
+                            'name' => $field->club->name,
+                            'address' => $field->club->address,
+                            'lat' => $field->club->lat,
+                            'lng' => $field->club->lng,
+                        ],
+                        'weather' => $weather->getWeather($field->club->lat, $field->club->lng),
+                    ];
+                })
+                ->values()
+                ->toArray();
+        });
+
+        return response()->json(['data' => $fields]);
+    }
+
+    private function distance($lat1, $lng1, $lat2, $lng2): float
+    {
+        $earthRadius = 6371; // km
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+
+        $a = sin($dLat / 2) ** 2 + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+        $c = 2 * atan2(sqrt($a), sqrt(1 - $a));
+
+        return $earthRadius * $c;
+    }
+}

--- a/backend/app/Services/WeatherService.php
+++ b/backend/app/Services/WeatherService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services;
+
+use GuzzleHttp\Client;
+
+class WeatherService
+{
+    public function __construct(private Client $client)
+    {
+    }
+
+    public function getWeather(float $lat, float $lng): array
+    {
+        $response = $this->client->get('https://api.open-meteo.com/v1/forecast', [
+            'query' => [
+                'latitude' => $lat,
+                'longitude' => $lng,
+                'current_weather' => true,
+            ],
+        ]);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "guzzlehttp/guzzle": "^7.8",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15cd0518b6cf4d1a0960fe04798f82ea",
+    "content-hash": "4022c0f3d8b2bccf5a4c56ad82fec771",
     "packages": [
         {
             "name": "brick/math",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\FieldController;
+use App\Http\Controllers\Api\NearbyFieldController;
 use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\PaymentWebhookController;
 use App\Http\Controllers\Api\ClubController;
@@ -17,6 +18,7 @@ Route::prefix('v1')->group(function () {
         Route::get('auth/user', [AuthController::class, 'user']);
         Route::post('auth/logout', [AuthController::class, 'logout']);
 
+        Route::get('fields/nearby', NearbyFieldController::class);
         Route::get('fields', [FieldController::class, 'index']);
 
         Route::get('tournaments', [TournamentController::class, 'index']);

--- a/backend/tests/Feature/Api/NearbyFieldTest.php
+++ b/backend/tests/Feature/Api/NearbyFieldTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Club;
+use App\Models\Field;
+use App\Models\User;
+use App\Services\WeatherService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NearbyFieldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_get_nearby_fields_with_weather_and_cache(): void
+    {
+        config(['cache.default' => 'redis', 'cache.stores.redis.driver' => 'array']);
+
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $clubNear = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Near Club',
+            'address' => 'Street 1',
+            'lat' => -34.6,
+            'lng' => -58.4,
+        ]);
+
+        Field::create([
+            'club_id' => $clubNear->id,
+            'name' => 'Near Field',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $clubFar = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Far Club',
+            'address' => 'Street 2',
+            'lat' => 10,
+            'lng' => 10,
+        ]);
+
+        Field::create([
+            'club_id' => $clubFar->id,
+            'name' => 'Far Field',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $this->mock(WeatherService::class, function ($mock) {
+            $mock->shouldReceive('getWeather')->once()->andReturn(['temp' => 20]);
+        });
+
+        $params = ['lat' => -34.6, 'lng' => -58.4];
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/fields/nearby?' . http_build_query($params));
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonFragment(['name' => 'Near Field'])
+            ->assertJsonFragment(['temp' => 20]);
+
+        // second request should hit cache, weather service not called again
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/fields/nearby?' . http_build_query($params));
+    }
+}

--- a/backend/tests/Feature/ExampleTest.php
+++ b/backend/tests/Feature/ExampleTest.php
@@ -12,6 +12,8 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
+        config(['app.key' => env('APP_KEY', 'base64:'.base64_encode(random_bytes(32)))]);
+
         $response = $this->get('/');
 
         $response->assertStatus(200);


### PR DESCRIPTION
## Summary
- add Guzzle dependency and weather service
- implement NearbyFieldController for `/api/v1/fields/nearby`
- cache field lookup in Redis and test weather integration

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ae05e7cdec832089122588f1ccc546