### PR TITLE
Add API auth and reservation flow tests with coverage reporting

### DIFF
--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -12,11 +12,15 @@
             <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <source>
+    <coverage>
         <include>
             <directory>app</directory>
         </include>
-    </source>
+        <report>
+            <html outputDirectory="coverage"/>
+            <text outputFile="php://stdout"/>
+        </report>
+    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>

--- a/backend/tests/Feature/Api/AuthTest.php
+++ b/backend/tests/Feature/Api/AuthTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register(): void
+    {
+        $response = $this->postJson('/api/v1/auth/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(201)
+                 ->assertJsonStructure(['token']);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'john@example.com',
+        ]);
+    }
+
+    public function test_user_can_login(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        $response = $this->postJson('/api/v1/auth/login', [
+            'email' => 'john@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure(['token']);
+    }
+
+    public function test_user_can_logout(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+                         ->postJson('/api/v1/auth/logout');
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment(['message' => 'Logged out']);
+    }
+}

--- a/backend/tests/Feature/Api/ReservationFlowTest.php
+++ b/backend/tests/Feature/Api/ReservationFlowTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Club;
+use App\Models\Field;
+use App\Models\Reservation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_create_reservation(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Cancha 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $start = now()->addDay();
+        $end = now()->addDay()->addHour();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/reservations', [
+                'field_id' => $field->id,
+                'start_time' => $start->toDateTimeString(),
+                'end_time' => $end->toDateTimeString(),
+                'total_price' => 100,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['field_id' => $field->id]);
+
+        $this->assertDatabaseHas('reservations', [
+            'field_id' => $field->id,
+            'user_id' => $user->id,
+            'status' => 'confirmed',
+        ]);
+    }
+
+    public function test_user_can_cancel_reservation(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Cancha 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $reservation = Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->deleteJson('/api/v1/reservations/' . $reservation->id);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['message' => 'Reservation cancelled']);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => 'cancelled',
+        ]);
+    }
+
+    public function test_user_can_reschedule_reservation(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Cancha 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        $reservation = Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        $newStart = now()->addDays(2);
+        $newEnd = now()->addDays(2)->addHour();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/reservations/' . $reservation->id, [
+                'start_time' => $newStart->toDateTimeString(),
+                'end_time' => $newEnd->toDateTimeString(),
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['rescheduled_from_id' => $reservation->id]);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => 'cancelled',
+        ]);
+
+        $this->assertDatabaseHas('reservations', [
+            'rescheduled_from_id' => $reservation->id,
+            'start_time' => $newStart->toDateTimeString(),
+            'end_time' => $newEnd->toDateTimeString(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature tests for auth register, login and logout
- cover reservation flow: create, cancel and reschedule
- configure PHPUnit to generate coverage reports

## Testing
- `composer test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a8603088320ab2397299153da60