### PR TITLE
Verify MercadoPago webhook signature and log events

### DIFF
--- a/backend/app/Http/Controllers/Api/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/Api/PaymentWebhookController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Payment;
 use App\Models\Reservation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class PaymentWebhookController extends Controller
 {
@@ -16,8 +17,10 @@ class PaymentWebhookController extends Controller
         $expected = hash_hmac('sha256', $request->getContent(), $secret ?? '');
 
         if (!$signature || !hash_equals($expected, $signature)) {
-            return response()->json(['message' => 'Invalid signature'], 401);
+            return response()->json(['message' => 'Invalid signature'], 400);
         }
+
+        Log::info('MercadoPago webhook validated', $request->all());
 
         $reservation = Reservation::findOrFail($request->input('reservation_id'));
         $status = $request->input('status', 'paid');

--- a/backend/tests/Feature/Api/PaymentWebhookTest.php
+++ b/backend/tests/Feature/Api/PaymentWebhookTest.php
@@ -69,7 +69,7 @@ class PaymentWebhookTest extends TestCase
         ];
     }
 
-    public function test_invalid_signature_returns_unauthorized(): void
+    public function test_invalid_signature_returns_bad_request(): void
     {
         config()->set('services.mercadopago.webhook_secret', 'secret');
 
@@ -102,6 +102,6 @@ class PaymentWebhookTest extends TestCase
 
         $this->withHeader('X-Signature', 'invalid')
             ->postJson('/api/v1/payments/webhook', $payload)
-            ->assertStatus(401);
+            ->assertStatus(400);
     }
 }


### PR DESCRIPTION
## Summary
- verify and log MercadoPago webhook signature
- expect 400 Bad Request on invalid signature

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68af54aebe648320a30562be18aa9fa0