### PR TITLE
Add web social login routes with integration test

### DIFF
--- a/backend/app/Http/Controllers/SocialAuthController.php
+++ b/backend/app/Http/Controllers/SocialAuthController.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Api;
-
-use App\Http\Controllers\Controller;
+namespace App\Http\Controllers;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -10,7 +10,6 @@ use App\Http\Controllers\Api\ClubController;
 use App\Http\Controllers\Api\PaymentController;
 use App\Http\Controllers\Api\TournamentController;
 use App\Http\Controllers\Api\PasswordResetController;
-use App\Http\Controllers\Api\SocialAuthController;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\Request;
 
@@ -19,8 +18,6 @@ Route::prefix('v1')->group(function () {
     Route::post('auth/login', [AuthController::class, 'login']);
     Route::post('auth/forgot-password', [PasswordResetController::class, 'sendResetLink'])->name('password.email');
     Route::post('auth/reset-password', [PasswordResetController::class, 'reset'])->name('password.reset');
-    Route::get('auth/{provider}/redirect', [SocialAuthController::class, 'redirect']);
-    Route::get('auth/{provider}/callback', [SocialAuthController::class, 'callback']);
 
     Route::middleware('auth:sanctum')->group(function () {
         Route::get('auth/user', [AuthController::class, 'user']);

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SocialAuthController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('auth/{provider}/redirect', [SocialAuthController::class, 'redirect']);
+Route::get('auth/{provider}/callback', [SocialAuthController::class, 'callback']);

--- a/backend/tests/Feature/Auth/SocialAuthTest.php
+++ b/backend/tests/Feature/Auth/SocialAuthTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api;
+namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -14,6 +14,8 @@ class SocialAuthTest extends TestCase
 
     public function test_callback_creates_user_and_returns_token(): void
     {
+        config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
+
         $socialUser = new SocialiteUser();
         $socialUser->map([
             'id' => '12345',
@@ -25,7 +27,7 @@ class SocialAuthTest extends TestCase
         Socialite::shouldReceive('stateless')->andReturnSelf();
         Socialite::shouldReceive('user')->andReturn($socialUser);
 
-        $response = $this->get('/api/v1/auth/github/callback');
+        $response = $this->get('/auth/github/callback');
 
         $response->assertStatus(200)->assertJsonStructure(['token']);
 


### PR DESCRIPTION
## Summary
- expose social login routes for `/auth/{provider}`
- implement SocialAuthController with redirect and callback
- test Socialite callback for user creation and token

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b5bdd05a248320825a118e5270062c