### PR TITLE
feat: add user reservation filters and weather alerts

### DIFF
--- a/backend/app/Http/Controllers/Api/UserReservationController.php
+++ b/backend/app/Http/Controllers/Api/UserReservationController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class UserReservationController extends Controller
+{
+    public function upcoming(Request $request)
+    {
+        return $request->user()->reservations()
+            ->where('status', 'confirmed')
+            ->where('start_time', '>', now())
+            ->with('field.club')
+            ->get();
+    }
+
+    public function pending(Request $request)
+    {
+        return $request->user()->reservations()
+            ->where('status', 'pending')
+            ->with('field.club')
+            ->get();
+    }
+
+    public function history(Request $request)
+    {
+        return $request->user()->reservations()
+            ->where('end_time', '<', now())
+            ->where('status', '!=', 'cancelled')
+            ->with('field.club')
+            ->get();
+    }
+
+    public function cancelled(Request $request)
+    {
+        return $request->user()->reservations()
+            ->where('status', 'cancelled')
+            ->with('field.club')
+            ->get();
+    }
+}

--- a/backend/app/Notifications/WeatherAlertNotification.php
+++ b/backend/app/Notifications/WeatherAlertNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class WeatherAlertNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Reservation $reservation, public array $weather)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $current = $this->weather['current_weather'] ?? [];
+        $description = $current['weathercode'] ?? '';
+        $temperature = $current['temperature'] ?? '';
+
+        return (new MailMessage)
+            ->subject('Weather Alert')
+            ->line('Upcoming reservation at ' . $this->reservation->start_time->toDateTimeString())
+            ->line('Weather code: ' . $description)
+            ->line('Temperature: ' . $temperature);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\FieldController;
 use App\Http\Controllers\Api\NearbyFieldController;
 use App\Http\Controllers\Api\ReservationController;
+use App\Http\Controllers\Api\UserReservationController;
 use App\Http\Controllers\Api\PaymentWebhookController;
 use App\Http\Controllers\Api\ClubController;
 use App\Http\Controllers\Api\PaymentController;
@@ -62,6 +63,11 @@ Route::prefix('v1')->group(function () {
         Route::put('reservations/{reservation}', [ReservationController::class, 'update']);
         Route::post('reservations/{reservation}/waitlist', [ReservationController::class, 'waitlist']);
         Route::delete('reservations/{reservation}', [ReservationController::class, 'destroy']);
+
+        Route::get('user/reservations/upcoming', [UserReservationController::class, 'upcoming']);
+        Route::get('user/reservations/pending', [UserReservationController::class, 'pending']);
+        Route::get('user/reservations/history', [UserReservationController::class, 'history']);
+        Route::get('user/reservations/cancelled', [UserReservationController::class, 'cancelled']);
 
         Route::post('payments/checkout', [PaymentController::class, 'checkout']);
     });

--- a/backend/tests/Feature/UserReservationsTest.php
+++ b/backend/tests/Feature/UserReservationsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Club;
+use App\Models\Field;
+use App\Models\Reservation;
+use App\Models\User;
+use App\Notifications\ReservationReminderNotification;
+use App\Notifications\WeatherAlertNotification;
+use App\Services\WeatherService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Sanctum\Sanctum;
+use Mockery;
+use Tests\TestCase;
+
+class UserReservationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setupUserAndField(): array
+    {
+        $user = User::factory()->create();
+
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+            'lat' => 0,
+            'lng' => 0,
+        ]);
+
+        $field = Field::create([
+            'club_id' => $club->id,
+            'name' => 'Field 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+
+        return [$user, $field];
+    }
+
+    public function test_user_reservation_filters(): void
+    {
+        [$user, $field] = $this->setupUserAndField();
+        Sanctum::actingAs($user);
+
+        Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDays(2),
+            'end_time' => now()->addDays(2)->addHour(),
+            'status' => 'pending',
+            'total_price' => 100,
+        ]);
+
+        Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->subDays(2),
+            'end_time' => now()->subDay(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        Reservation::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDays(3),
+            'end_time' => now()->addDays(3)->addHour(),
+            'status' => 'cancelled',
+            'total_price' => 100,
+        ]);
+
+        $this->getJson('/api/v1/user/reservations/upcoming')
+            ->assertStatus(200)
+            ->assertJsonCount(1);
+
+        $this->getJson('/api/v1/user/reservations/pending')
+            ->assertStatus(200)
+            ->assertJsonCount(1);
+
+        $this->getJson('/api/v1/user/reservations/history')
+            ->assertStatus(200)
+            ->assertJsonCount(1);
+
+        $this->getJson('/api/v1/user/reservations/cancelled')
+            ->assertStatus(200)
+            ->assertJsonCount(1);
+    }
+
+    public function test_store_sends_notifications(): void
+    {
+        [$user, $field] = $this->setupUserAndField();
+        Sanctum::actingAs($user);
+
+        Notification::fake();
+
+        $weather = Mockery::mock(WeatherService::class);
+        $weather->shouldReceive('getWeather')->andReturn([
+            'current_weather' => ['temperature' => 20, 'weathercode' => 0],
+        ]);
+        $this->app->instance(WeatherService::class, $weather);
+
+        $response = $this->postJson('/api/v1/reservations', [
+            'field_id' => $field->id,
+            'start_time' => now()->addDay()->toDateTimeString(),
+            'end_time' => now()->addDay()->addHour()->toDateTimeString(),
+            'total_price' => 100,
+        ]);
+
+        $response->assertStatus(201);
+
+        Notification::assertSentTo($user, ReservationReminderNotification::class);
+        Notification::assertSentTo($user, WeatherAlertNotification::class);
+    }
+}

--- a/backend/tests/Unit/Notifications/ReservationReminderNotificationTest.php
+++ b/backend/tests/Unit/Notifications/ReservationReminderNotificationTest.php
@@ -59,8 +59,11 @@ class ReservationReminderNotificationTest extends TestCase
         ]);
         $request->setUserResolver(fn () => $user);
 
+        $weather = \Mockery::mock(\App\Services\WeatherService::class);
+        $weather->shouldReceive('getWeather')->andReturn([]);
+
         $controller = new ReservationController();
-        $controller->store($request);
+        $controller->store($request, $weather);
 
         Notification::assertSentTo($user, ReservationReminderNotification::class);
         $notification = Notification::sent($user, ReservationReminderNotification::class)->first();


### PR DESCRIPTION
## Summary
- add controller with user reservation filters
- send queued weather alert notifications
- cover reservations with new feature tests

## Testing
- `php artisan test`
- `php artisan test --filter=UserReservationsTest`

------
https://chatgpt.com/codex/tasks/task_e_68b7820f80bc8320b47e9022c8fcebeb