### PR TITLE
Add admin dashboard metrics and manual payment confirmation

### DIFF
--- a/backend/app/Http/Controllers/Api/AdminReportController.php
+++ b/backend/app/Http/Controllers/Api/AdminReportController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Field;
+use App\Models\Reservation;
+
+class AdminReportController extends Controller
+{
+    public function occupancy()
+    {
+        $now = now();
+
+        $occupied = Reservation::where('status', 'confirmed')
+            ->where('start_time', '<=', $now)
+            ->where('end_time', '>', $now)
+            ->count();
+
+        $total = Field::count();
+        $rate = $total > 0 ? round(($occupied / $total) * 100, 2) : 0;
+
+        return response()->json([
+            'occupied' => $occupied,
+            'total' => $total,
+            'occupancy_rate' => $rate,
+        ]);
+    }
+
+    public function reservations()
+    {
+        $total = Reservation::count();
+        $confirmed = Reservation::where('status', 'confirmed')->count();
+        $cancelled = Reservation::where('status', 'cancelled')->count();
+        $pending = Reservation::where('status', 'pending')->count();
+
+        return response()->json([
+            'total' => $total,
+            'confirmed' => $confirmed,
+            'cancelled' => $cancelled,
+            'pending' => $pending,
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/AdminReservationController.php
+++ b/backend/app/Http/Controllers/Api/AdminReservationController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+
+class AdminReservationController extends Controller
+{
+    public function confirmManualPayment(Reservation $reservation)
+    {
+        $payment = $reservation->payment()
+            ->where('provider', 'manual')
+            ->first();
+
+        if (!$payment) {
+            return response()->json(['message' => 'Manual payment not found'], 404);
+        }
+
+        $payment->update(['status' => 'paid']);
+        $reservation->update(['status' => 'confirmed']);
+
+        return response()->json($payment);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -11,6 +11,8 @@ use App\Http\Controllers\Api\ClubController;
 use App\Http\Controllers\Api\PaymentController;
 use App\Http\Controllers\Api\TournamentController;
 use App\Http\Controllers\Api\PasswordResetController;
+use App\Http\Controllers\Api\AdminReportController;
+use App\Http\Controllers\Api\AdminReservationController;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\Request;
 
@@ -56,6 +58,10 @@ Route::prefix('v1')->group(function () {
 
             Route::post('payments/manual', [PaymentController::class, 'manual']);
             Route::post('payments/{payment}/confirm', [PaymentController::class, 'confirm']);
+
+            Route::get('reports/occupancy', [AdminReportController::class, 'occupancy']);
+            Route::get('reports/reservations', [AdminReportController::class, 'reservations']);
+            Route::post('reservations/{reservation}/confirm-manual-payment', [AdminReservationController::class, 'confirmManualPayment']);
         });
 
         Route::get('reservations', [ReservationController::class, 'index']);

--- a/backend/tests/Feature/AdminDashboardTest.php
+++ b/backend/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Club;
+use App\Models\Field;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminToken(?User &$user = null): string
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        return $user->createToken('test')->plainTextToken;
+    }
+
+    private function createField(User $admin): Field
+    {
+        $club = Club::create([
+            'user_id' => $admin->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        return Field::create([
+            'club_id' => $club->id,
+            'name' => 'Field 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+    }
+
+    public function test_admin_can_view_occupancy_metrics(): void
+    {
+        $token = $this->adminToken($admin);
+        $field = $this->createField($admin);
+
+        Carbon::setTestNow('2023-01-01 10:00:00');
+        Reservation::create([
+            'user_id' => $admin->id,
+            'field_id' => $field->id,
+            'start_time' => now(),
+            'end_time' => now()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/reports/occupancy');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'occupied' => 1,
+                'total' => 1,
+                'occupancy_rate' => 100,
+            ]);
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_can_view_reservation_metrics(): void
+    {
+        $token = $this->adminToken($admin);
+        $field = $this->createField($admin);
+
+        Reservation::create([
+            'user_id' => $admin->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'confirmed',
+            'total_price' => 100,
+        ]);
+
+        Reservation::create([
+            'user_id' => $admin->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDays(2),
+            'end_time' => now()->addDays(2)->addHour(),
+            'status' => 'cancelled',
+            'total_price' => 100,
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/reports/reservations');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'total' => 2,
+                'confirmed' => 1,
+                'cancelled' => 1,
+            ]);
+    }
+
+    public function test_admin_can_confirm_manual_payment(): void
+    {
+        $token = $this->adminToken($admin);
+        $field = $this->createField($admin);
+
+        $reservation = Reservation::create([
+            'user_id' => $admin->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'pending',
+            'total_price' => 100,
+        ]);
+
+        Payment::create([
+            'reservation_id' => $reservation->id,
+            'provider' => 'manual',
+            'status' => 'pending',
+            'amount' => 100,
+            'payload' => [],
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/reservations/' . $reservation->id . '/confirm-manual-payment');
+
+        $response->assertStatus(200)
+            ->assertJson(['status' => 'paid']);
+
+        $this->assertDatabaseHas('reservations', [
+            'id' => $reservation->id,
+            'status' => 'confirmed',
+        ]);
+    }
+
+    public function test_user_cannot_access_admin_endpoints(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/reports/occupancy')
+            ->assertStatus(403);
+
+        $adminToken = $this->adminToken($admin);
+        $field = $this->createField($admin);
+        $reservation = Reservation::create([
+            'user_id' => $admin->id,
+            'field_id' => $field->id,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+            'status' => 'pending',
+            'total_price' => 100,
+        ]);
+        Payment::create([
+            'reservation_id' => $reservation->id,
+            'provider' => 'manual',
+            'status' => 'pending',
+            'amount' => 100,
+            'payload' => [],
+        ]);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/reservations/' . $reservation->id . '/confirm-manual-payment')
+            ->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- add report endpoints for field occupancy and reservation stats
- allow admins to confirm manual payments on reservations
- cover admin dashboard features with feature tests

## Testing
- `cd backend && ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68b85d625e6483208513c45d39ce89d6