### PR TITLE
Add field review CRUD endpoints

### DIFF
--- a/backend/app/Http/Controllers/Api/ReviewController.php
+++ b/backend/app/Http/Controllers/Api/ReviewController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ReviewRequest;
+use App\Models\Field;
+use App\Models\Review;
+use Illuminate\Http\Request;
+
+class ReviewController extends Controller
+{
+    public function index(Field $field)
+    {
+        return $field->reviews()->paginate();
+    }
+
+    public function store(ReviewRequest $request, Field $field)
+    {
+        $review = $field->reviews()->create([
+            'user_id' => $request->user()->id,
+            'rating' => $request->input('rating'),
+            'comment' => $request->input('comment'),
+        ]);
+
+        return response()->json($review, 201);
+    }
+
+    public function show(Field $field, Review $review)
+    {
+        abort_if($review->field_id !== $field->id, 404);
+
+        return $review;
+    }
+
+    public function update(ReviewRequest $request, Field $field, Review $review)
+    {
+        abort_if($review->field_id !== $field->id, 404);
+
+        if ($request->user()->id !== $review->user_id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $review->update($request->validated());
+
+        return response()->json($review);
+    }
+
+    public function destroy(Request $request, Field $field, Review $review)
+    {
+        abort_if($review->field_id !== $field->id, 404);
+
+        if ($request->user()->id !== $review->user_id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $review->delete();
+
+        return response()->noContent();
+    }
+}

--- a/backend/app/Http/Requests/ReviewRequest.php
+++ b/backend/app/Http/Requests/ReviewRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReviewRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'rating' => 'required|integer|min:1|max:5',
+            'comment' => 'nullable|string',
+        ];
+    }
+}

--- a/backend/app/Models/Field.php
+++ b/backend/app/Models/Field.php
@@ -32,4 +32,9 @@ class Field extends Model
     {
         return $this->hasMany(Reservation::class);
     }
+
+    public function reviews(): HasMany
+    {
+        return $this->hasMany(Review::class);
+    }
 }

--- a/backend/app/Models/Review.php
+++ b/backend/app/Models/Review.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Review extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'field_id',
+        'rating',
+        'comment',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function field(): BelongsTo
+    {
+        return $this->belongsTo(Field::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -53,4 +53,9 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasMany(Reservation::class);
     }
+
+    public function reviews(): HasMany
+    {
+        return $this->hasMany(Review::class);
+    }
 }

--- a/backend/database/migrations/2025_08_22_184311_create_reviews_table.php
+++ b/backend/database/migrations/2025_08_22_184311_create_reviews_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('field_id')->constrained()->cascadeOnDelete();
+            $table->unsignedTinyInteger('rating');
+            $table->text('comment')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reviews');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Api\TournamentController;
 use App\Http\Controllers\Api\PasswordResetController;
 use App\Http\Controllers\Api\AdminReportController;
 use App\Http\Controllers\Api\AdminReservationController;
+use App\Http\Controllers\Api\ReviewController;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\Request;
 
@@ -76,6 +77,8 @@ Route::prefix('v1')->group(function () {
         Route::get('user/reservations/cancelled', [UserReservationController::class, 'cancelled']);
 
         Route::post('payments/checkout', [PaymentController::class, 'checkout']);
+
+        Route::apiResource('fields.reviews', ReviewController::class)->except(['create', 'edit']);
     });
 
     Route::post('payments/webhook', PaymentWebhookController::class);

--- a/backend/tests/Feature/ReviewsTest.php
+++ b/backend/tests/Feature/ReviewsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Club;
+use App\Models\Field;
+use App\Models\Review;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReviewsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function userToken(User &$user = null): string
+    {
+        $user = User::factory()->create();
+        return $user->createToken('test')->plainTextToken;
+    }
+
+    private function createField(): Field
+    {
+        $owner = User::factory()->create();
+        $club = Club::create([
+            'user_id' => $owner->id,
+            'name' => 'Club Center',
+            'address' => 'Street 1',
+        ]);
+
+        return Field::create([
+            'club_id' => $club->id,
+            'name' => 'Field 1',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+    }
+
+    public function test_user_can_list_reviews(): void
+    {
+        $token = $this->userToken($user);
+        $field = $this->createField();
+        Review::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'rating' => 4,
+            'comment' => 'Good field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/fields/' . $field->id . '/reviews');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['data' => [['id', 'rating']]]);
+    }
+
+    public function test_user_can_show_review(): void
+    {
+        $token = $this->userToken($user);
+        $field = $this->createField();
+        $review = Review::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'rating' => 4,
+            'comment' => 'Good field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/fields/' . $field->id . '/reviews/' . $review->id);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['id' => $review->id]);
+    }
+
+    public function test_user_can_create_review(): void
+    {
+        $token = $this->userToken($user);
+        $field = $this->createField();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/fields/' . $field->id . '/reviews', [
+                'rating' => 5,
+                'comment' => 'Excellent',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['rating' => 5]);
+    }
+
+    public function test_user_can_update_own_review(): void
+    {
+        $token = $this->userToken($user);
+        $field = $this->createField();
+        $review = Review::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'rating' => 4,
+            'comment' => 'Good field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/fields/' . $field->id . '/reviews/' . $review->id, [
+                'rating' => 3,
+                'comment' => 'Okay',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['rating' => 3]);
+    }
+
+    public function test_user_can_delete_own_review(): void
+    {
+        $token = $this->userToken($user);
+        $field = $this->createField();
+        $review = Review::create([
+            'user_id' => $user->id,
+            'field_id' => $field->id,
+            'rating' => 4,
+            'comment' => 'Good field',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->deleteJson('/api/v1/fields/' . $field->id . '/reviews/' . $review->id);
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('reviews', ['id' => $review->id]);
+    }
+
+    public function test_validation_fails_with_invalid_rating(): void
+    {
+        $token = $this->userToken($user);
+        $field = $this->createField();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/fields/' . $field->id . '/reviews', [
+                'rating' => 6,
+            ]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- add Review model and migration relating users and fields
- implement ReviewController with nested `/fields/{field}/reviews` routes
- cover review operations with feature tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b89592ec348320b76cf51a49fb0281