### PR TITLE
docs: document tournaments and add tests

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -100,11 +100,29 @@ paths:
     get:
       summary: List tournaments
       responses:
-        '200': {description: OK}
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Tournament'
     post:
       summary: Create tournament
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TournamentRequest'
       responses:
-        '201': {description: Created}
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tournament'
   /tournaments/{id}:
     get:
       summary: Show tournament
@@ -114,7 +132,12 @@ paths:
           required: true
           schema: {type: integer}
       responses:
-        '200': {description: OK}
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tournament'
     put:
       summary: Update tournament
       parameters:
@@ -122,8 +145,19 @@ paths:
           in: path
           required: true
           schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TournamentRequest'
       responses:
-        '200': {description: OK}
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tournament'
     delete:
       summary: Delete tournament
       parameters:
@@ -141,8 +175,24 @@ paths:
           in: path
           required: true
           schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - team_name
+              properties:
+                team_name:
+                  type: string
       responses:
-        '201': {description: Created}
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Registration'
   /reservations:
     get:
       summary: List user reservations
@@ -359,3 +409,62 @@ components:
         amount:
           type: number
           format: float
+    TournamentRequest:
+      type: object
+      required:
+        - name
+        - start_date
+      properties:
+        name:
+          type: string
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+          nullable: true
+        location:
+          type: string
+          nullable: true
+    Tournament:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        start_date:
+          type: string
+          format: date
+        end_date:
+          type: string
+          format: date
+          nullable: true
+        location:
+          type: string
+          nullable: true
+        teams:
+          type: array
+          items:
+            $ref: '#/components/schemas/Team'
+    Team:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    Registration:
+      type: object
+      properties:
+        id:
+          type: integer
+        tournament_id:
+          type: integer
+        team_id:
+          type: integer
+        team:
+          $ref: '#/components/schemas/Team'
+        tournament:
+          $ref: '#/components/schemas/Tournament'

--- a/backend/tests/Feature/TournamentsTest.php
+++ b/backend/tests/Feature/TournamentsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tournament;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TournamentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminToken(?User &$user = null): string
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        return $user->createToken('test')->plainTextToken;
+    }
+
+    private function userToken(?User &$user = null): string
+    {
+        $user = User::factory()->create();
+        return $user->createToken('test')->plainTextToken;
+    }
+
+    public function test_user_can_list_tournaments(): void
+    {
+        $token = $this->userToken();
+        Tournament::create([
+            'name' => 'Summer Cup',
+            'start_date' => '2025-01-01',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v1/tournaments');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['data']);
+    }
+
+    public function test_admin_can_create_tournament(): void
+    {
+        $token = $this->adminToken();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/tournaments', [
+                'name' => 'Create Cup',
+                'start_date' => '2025-02-01',
+                'end_date' => '2025-02-10',
+                'location' => 'City Arena',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['name' => 'Create Cup']);
+    }
+
+    public function test_admin_can_update_tournament(): void
+    {
+        $token = $this->adminToken($admin);
+        $tournament = Tournament::create([
+            'name' => 'Old Cup',
+            'start_date' => '2025-03-01',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/v1/tournaments/' . $tournament->id, [
+                'name' => 'New Cup',
+                'start_date' => '2025-03-01',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'New Cup']);
+    }
+
+    public function test_admin_can_delete_tournament(): void
+    {
+        $token = $this->adminToken($admin);
+        $tournament = Tournament::create([
+            'name' => 'Delete Cup',
+            'start_date' => '2025-04-01',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->deleteJson('/api/v1/tournaments/' . $tournament->id);
+
+        $response->assertStatus(204);
+    }
+
+    public function test_user_can_register_team_to_tournament(): void
+    {
+        $token = $this->userToken();
+        $tournament = Tournament::create([
+            'name' => 'Register Cup',
+            'start_date' => '2025-05-01',
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/tournaments/' . $tournament->id . '/register', [
+                'team_name' => 'Warriors',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('team.name', 'Warriors');
+    }
+
+    public function test_user_cannot_create_tournament(): void
+    {
+        $token = $this->userToken();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/tournaments', [
+                'name' => 'Nope Cup',
+                'start_date' => '2025-06-01',
+            ]);
+
+        $response->assertStatus(403);
+    }
+}
+


### PR DESCRIPTION
## Summary
- document tournament CRUD and registration endpoints in OpenAPI spec
- add feature tests for tournament CRUD and registration

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0192ef7c832080f15a9b5acb53f8