### PR TITLE
Add API spec coverage and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Validate OpenAPI spec
+        run: |
+          npm install -g @apidevtools/swagger-cli
+          swagger-cli validate backend/openapi.yaml
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install Composer dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist
+      - name: Prepare environment
+        working-directory: backend
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+      - name: Run tests
+        working-directory: backend
+        run: php artisan test

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ pnpm run build
 
 ## API
 
-Documentation for the backend endpoints is available in the OpenAPI format. You can view it using Swagger UI [here](backend/openapi.html).
+Documentation for the backend endpoints is available in the OpenAPI format. The HTML documentation generated with Swagger UI can be found [here](backend/openapi.html).

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -25,6 +25,41 @@ paths:
       summary: Login user
       responses:
         '200': {description: Token}
+  /auth/forgot-password:
+    post:
+      summary: Send password reset link
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email: {type: string}
+      responses:
+        '200': {description: Link sent}
+  /auth/reset-password:
+    post:
+      summary: Reset user password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token, email, password]
+              properties:
+                token: {type: string}
+                email: {type: string}
+                password: {type: string}
+      responses:
+        '200': {description: Password reset}
+  /auth/logout:
+    post:
+      summary: Logout user
+      responses:
+        '200': {description: Logged out}
   /auth/{provider}/redirect:
     get:
       summary: Redirect to social auth provider
@@ -96,6 +131,65 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Field'
+    post:
+      summary: Create field
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FieldRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Field'
+  /fields/{id}:
+    get:
+      summary: Show field
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Field'
+    put:
+      summary: Update field
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FieldRequest'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Field'
+    delete:
+      summary: Delete field
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '204': {description: No Content}
   /tournaments:
     get:
       summary: List tournaments
@@ -221,6 +315,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/Reservation'
   /reservations/{id}:
+    put:
+      summary: Update reservation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReservationRequest'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reservation'
     delete:
       summary: Cancel reservation
       parameters:
@@ -238,6 +352,24 @@ paths:
                 properties:
                   message:
                     type: string
+  /reservations/{id}/waitlist:
+    post:
+      summary: Join reservation waitlist
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '201':
+          description: Joined
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  position:
+                    type: integer
   /payments/checkout:
     post:
       summary: Checkout payment
@@ -261,6 +393,37 @@ paths:
                   init_point:
                     type: string
                     nullable: true
+  /payments/manual:
+    post:
+      summary: Register manual payment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentManualRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+  /payments/{id}/confirm:
+    post:
+      summary: Confirm manual payment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200':
+          description: Confirmed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
   /payments/webhook:
     post:
       summary: MercadoPago webhook
@@ -336,6 +499,30 @@ components:
         price_per_hour:
           type: number
           format: float
+    FieldRequest:
+      type: object
+      required:
+        - club_id
+        - name
+        - sport
+        - price_per_hour
+      properties:
+        club_id:
+          type: integer
+        name:
+          type: string
+        sport:
+          type: string
+        surface:
+          type: string
+          nullable: true
+        indoor:
+          type: boolean
+        lighting:
+          type: boolean
+        price_per_hour:
+          type: number
+          format: float
     ReservationRequest:
       type: object
       required:
@@ -382,6 +569,17 @@ components:
       properties:
         reservation_id:
           type: integer
+    PaymentManualRequest:
+      type: object
+      required:
+        - reservation_id
+        - amount
+      properties:
+        reservation_id:
+          type: integer
+        amount:
+          type: number
+          format: float
     PaymentWebhookRequest:
       type: object
       required:

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -11,6 +11,23 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Authentication">
+            <file>tests/Feature/Api/AuthTest.php</file>
+            <directory>tests/Feature/Auth</directory>
+        </testsuite>
+        <testsuite name="Fields">
+            <file>tests/Feature/FieldsTest.php</file>
+        </testsuite>
+        <testsuite name="Reservations">
+            <file>tests/Feature/ReservationAdvancedTest.php</file>
+            <file>tests/Feature/UserReservationsTest.php</file>
+        </testsuite>
+        <testsuite name="Payments">
+            <file>tests/Feature/PaymentsTest.php</file>
+        </testsuite>
+        <testsuite name="Tournaments">
+            <file>tests/Feature/TournamentsTest.php</file>
+        </testsuite>
     </testsuites>
     <coverage>
         <include>

--- a/backend/tests/Unit/Notifications/ReservationReminderNotificationTest.php
+++ b/backend/tests/Unit/Notifications/ReservationReminderNotificationTest.php
@@ -8,6 +8,7 @@ use App\Models\Club;
 use App\Models\Field;
 use App\Models\User;
 use App\Notifications\ReservationReminderNotification;
+use App\Services\CalendarService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Notification;
@@ -61,9 +62,11 @@ class ReservationReminderNotificationTest extends TestCase
 
         $weather = \Mockery::mock(\App\Services\WeatherService::class);
         $weather->shouldReceive('getWeather')->andReturn([]);
+        $calendar = \Mockery::mock(CalendarService::class);
+        $calendar->shouldReceive('createEvent')->once();
 
         $controller = new ReservationController();
-        $controller->store($request, $weather);
+        $controller->store($request, $weather, $calendar);
 
         Notification::assertSentTo($user, ReservationReminderNotification::class);
         $notification = Notification::sent($user, ReservationReminderNotification::class)->first();


### PR DESCRIPTION
## Summary
- document authentication, field, reservation, payment and tournament endpoints in OpenAPI
- define dedicated PHPUnit test suites and fix calendar dependency in notification test
- add CI workflow to validate OpenAPI and run Laravel tests

## Testing
- `npx @apidevtools/swagger-cli@4.0.4 validate backend/openapi.yaml`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bb333d8d74832096e91bf345995cd0