### PR TITLE
feat: integrate fields API with filtering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import MyBookings from './pages/MyBookings';
 import AdminDashboard from './pages/admin/AdminDashboard';
 import Tournaments from './pages/Tournaments';
 import NotFound from './pages/NotFound';
+import FieldsPage from './pages/FieldsPage';
+import FieldDetails from './pages/FieldDetails';
 
 const queryClient = new QueryClient();
 
@@ -32,6 +34,8 @@ const App = () => (
               <Route path="/bookings" element={<MyBookings />} />
               <Route path="/admin" element={<AdminDashboard />} />
               <Route path="/tournaments" element={<Tournaments />} />
+              <Route path="/fields" element={<FieldsPage />} />
+              <Route path="/fields/:fieldId" element={<FieldDetails />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Layout>

--- a/src/components/FieldCard.tsx
+++ b/src/components/FieldCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Field } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  field: Field;
+}
+
+const FieldCard: React.FC<Props> = ({ field }) => (
+  <Card className="mb-4">
+    <CardHeader>
+      <CardTitle>{field.name}</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p className="text-sm">Deporte: {field.sport}</p>
+      <p className="text-sm">Precio: ${field.price_per_hour}</p>
+      <Link to={`/fields/${field.id}`} className="text-blue-500 text-sm">
+        Ver detalles
+      </Link>
+    </CardContent>
+  </Card>
+);
+
+export default FieldCard;

--- a/src/lib/api/fields.ts
+++ b/src/lib/api/fields.ts
@@ -1,0 +1,22 @@
+import api from '../api';
+import { Field } from '@/types';
+
+interface FieldFilters {
+  sport?: string;
+  price?: number;
+  date?: string;
+}
+
+export const listFields = async (filters: FieldFilters = {}): Promise<Field[]> => {
+  const response = await api.get('/api/v1/fields', {
+    params: filters,
+  });
+  return response.data.data ?? response.data;
+};
+
+export const getField = async (id: string | number): Promise<Field> => {
+  const response = await api.get(`/api/v1/fields/${id}`);
+  return response.data;
+};
+
+export default { listFields, getField };

--- a/src/pages/FieldDetails.tsx
+++ b/src/pages/FieldDetails.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getField } from '@/lib/api/fields';
+import { Field } from '@/types';
+
+const FieldDetails: React.FC = () => {
+  const { fieldId } = useParams<{ fieldId: string }>();
+  const [field, setField] = useState<Field | null>(null);
+
+  useEffect(() => {
+    if (!fieldId) return;
+    const fetchField = async () => {
+      const data = await getField(fieldId);
+      setField(data);
+    };
+    fetchField();
+  }, [fieldId]);
+
+  if (!field) {
+    return <div className="container mx-auto px-4 py-6">Cargando...</div>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <h1 className="text-2xl font-bold mb-4">{field.name}</h1>
+      <p className="mb-2">Deporte: {field.sport}</p>
+      <p className="mb-2">Precio por hora: ${field.price_per_hour}</p>
+    </div>
+  );
+};
+
+export default FieldDetails;

--- a/src/pages/FieldsPage.tsx
+++ b/src/pages/FieldsPage.tsx
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import { listFields } from '@/lib/api/fields';
+import { Field } from '@/types';
+import FieldCard from '@/components/FieldCard';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+
+const FieldsPage: React.FC = () => {
+  const [fields, setFields] = useState<Field[]>([]);
+  const [sport, setSport] = useState<string>('');
+  const [price, setPrice] = useState<number>();
+  const [date, setDate] = useState<string>('');
+
+  useEffect(() => {
+    const fetchFields = async () => {
+      const data = await listFields({
+        sport: sport || undefined,
+        price,
+        date: date || undefined,
+      });
+      setFields(data);
+    };
+    fetchFields();
+  }, [sport, price, date]);
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <h1 className="text-2xl font-bold mb-4">Canchas</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div>
+          <Label>Deporte</Label>
+          <Select value={sport} onValueChange={setSport}>
+            <SelectTrigger className="mt-1">
+              <SelectValue placeholder="Todos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Todos</SelectItem>
+              <SelectItem value="football">Fútbol</SelectItem>
+              <SelectItem value="paddle">Padel</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label>Precio máximo</Label>
+          <Input
+            type="number"
+            value={price?.toString() || ''}
+            onChange={(e) => setPrice(e.target.value ? Number(e.target.value) : undefined)}
+            placeholder="Precio"
+            className="mt-1"
+          />
+        </div>
+
+        <div>
+          <Label>Fecha</Label>
+          <Input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="mt-1"
+          />
+        </div>
+      </div>
+
+      {fields.map((field) => (
+        <FieldCard key={field.id} field={field} />
+      ))}
+    </div>
+  );
+};
+
+export default FieldsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,18 @@ export interface Club {
   createdAt: string;
 }
 
+export interface Field {
+  id: number;
+  club_id: number;
+  name: string;
+  sport: string;
+  surface: string;
+  indoor: boolean;
+  lighting: boolean;
+  price_per_hour: number;
+  club?: Club;
+}
+
 export interface Court {
   id: string;
   clubId: string;


### PR DESCRIPTION
## Summary
- add API helpers to list and fetch fields
- display fields with filter UI and detail page
- wire up new routes and types

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb3b2811e88320b27cc96216ed1047