### PR TITLE
feat: add reservation API and integrate pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,8 @@ import Home from './pages/Home';
 import Login from './pages/auth/Login';
 import Register from './pages/auth/Register';
 import Search from './pages/Search';
-import Booking from './pages/Booking';
-import MyBookings from './pages/MyBookings';
+import ReservationForm from './pages/ReservationForm';
+import MyReservations from './pages/MyReservations';
 import AdminDashboard from './pages/admin/AdminDashboard';
 import Tournaments from './pages/Tournaments';
 import NotFound from './pages/NotFound';
@@ -30,8 +30,8 @@ const App = () => (
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />
               <Route path="/search" element={<Search />} />
-              <Route path="/book/:courtId" element={<Booking />} />
-              <Route path="/bookings" element={<MyBookings />} />
+              <Route path="/book/:courtId" element={<ReservationForm />} />
+              <Route path="/bookings" element={<MyReservations />} />
               <Route path="/admin" element={<AdminDashboard />} />
               <Route path="/tournaments" element={<Tournaments />} />
               <Route path="/fields" element={<FieldsPage />} />

--- a/src/lib/api/reservations.ts
+++ b/src/lib/api/reservations.ts
@@ -1,0 +1,30 @@
+import api from '../api';
+import { Booking } from '@/types';
+
+interface ReservationPayload {
+  field_id: number;
+  start_time: string;
+  end_time: string;
+  total_price: number;
+  recurring_rule?: string;
+}
+
+export const createReservation = async (
+  payload: ReservationPayload
+): Promise<Booking> => {
+  const response = await api.post('/api/v1/reservations', payload);
+  return response.data;
+};
+
+export const cancelReservation = async (
+  id: string | number
+): Promise<void> => {
+  await api.delete(`/api/v1/reservations/${id}`);
+};
+
+export const listUserReservations = async (): Promise<Booking[]> => {
+  const response = await api.get('/api/v1/reservations');
+  return response.data.data ?? response.data;
+};
+
+export default { createReservation, cancelReservation, listUserReservations };


### PR DESCRIPTION
## Summary
- add reservation API helpers for create, cancel and list
- wire reservation form to backend and surface server errors
- load and manage user reservations from API instead of mocks

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb47bfea148320a7c20f9767abdbfd