### PR TITLE
Implement payment checkout and confirmation flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import Tournaments from './pages/Tournaments';
 import NotFound from './pages/NotFound';
 import FieldsPage from './pages/FieldsPage';
 import FieldDetails from './pages/FieldDetails';
+import PaymentPage from './pages/PaymentPage';
+import PaymentConfirmationPage from './pages/PaymentConfirmationPage';
 
 const queryClient = new QueryClient();
 
@@ -36,6 +38,11 @@ const App = () => (
               <Route path="/tournaments" element={<Tournaments />} />
               <Route path="/fields" element={<FieldsPage />} />
               <Route path="/fields/:fieldId" element={<FieldDetails />} />
+              <Route path="/payments/:id" element={<PaymentPage />} />
+              <Route
+                path="/payments/:id/confirmation"
+                element={<PaymentConfirmationPage />}
+              />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Layout>

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -1,0 +1,18 @@
+import api from '../api';
+
+interface CheckoutPayload {
+  reservation_id: number | string;
+}
+
+interface CheckoutResponse {
+  init_point: string;
+}
+
+export const checkout = async (
+  payload: CheckoutPayload
+): Promise<CheckoutResponse> => {
+  const response = await api.post('/api/v1/payments/checkout', payload);
+  return response.data;
+};
+
+export default { checkout };

--- a/src/lib/api/reservations.ts
+++ b/src/lib/api/reservations.ts
@@ -27,4 +27,16 @@ export const listUserReservations = async (): Promise<Booking[]> => {
   return response.data.data ?? response.data;
 };
 
-export default { createReservation, cancelReservation, listUserReservations };
+export const getReservation = async (
+  id: string | number
+): Promise<Booking> => {
+  const response = await api.get(`/api/v1/reservations/${id}`);
+  return response.data;
+};
+
+export default {
+  createReservation,
+  cancelReservation,
+  listUserReservations,
+  getReservation,
+};

--- a/src/pages/PaymentConfirmationPage.tsx
+++ b/src/pages/PaymentConfirmationPage.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getReservation } from '@/lib/api/reservations';
+import { Booking } from '@/types';
+
+const PaymentConfirmationPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [reservation, setReservation] = useState<Booking | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchReservation = async () => {
+      if (!id) return;
+      try {
+        const data = await getReservation(id);
+        setReservation(data);
+      } catch (error) {
+        console.error('Error fetching reservation', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchReservation();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-6 text-center">
+        <p>Verificando pago...</p>
+      </div>
+    );
+  }
+
+  if (!reservation || reservation.paymentStatus !== 'paid') {
+    return (
+      <div className="container mx-auto px-4 py-6 text-center">
+        <p>Pago pendiente. Si ya realizaste el pago, espera unos momentos e intenta nuevamente.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6 text-center">
+      <p>¡Pago confirmado! Tu reserva está activa.</p>
+    </div>
+  );
+};
+
+export default PaymentConfirmationPage;

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { checkout } from '@/lib/api/payments';
+
+const PaymentPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+
+  useEffect(() => {
+    const init = async () => {
+      if (!id) return;
+      try {
+        const { init_point } = await checkout({ reservation_id: id });
+        window.location.href = init_point;
+      } catch (error) {
+        console.error('Error initiating checkout', error);
+      }
+    };
+    init();
+  }, [id]);
+
+  return (
+    <div className="container mx-auto px-4 py-6 text-center">
+      <p>Redirigiendo a la plataforma de pagos...</p>
+    </div>
+  );
+};
+
+export default PaymentPage;


### PR DESCRIPTION
## Summary
- add payments API with checkout call
- redirect to provider in payment page
- show confirmation page that verifies reservation payment status

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb625868088320ab3ac6307749dd15