### PR TITLE
feat: add user reservation endpoints

### DIFF
--- a/src/lib/api/userReservations.ts
+++ b/src/lib/api/userReservations.ts
@@ -1,0 +1,29 @@
+import api from '../api';
+import { Booking } from '@/types';
+
+export const upcoming = async (): Promise<Booking[]> => {
+  const response = await api.get('/api/v1/user/reservations/upcoming');
+  return response.data;
+};
+
+export const pending = async (): Promise<Booking[]> => {
+  const response = await api.get('/api/v1/user/reservations/pending');
+  return response.data;
+};
+
+export const history = async (): Promise<Booking[]> => {
+  const response = await api.get('/api/v1/user/reservations/history');
+  return response.data;
+};
+
+export const cancelled = async (): Promise<Booking[]> => {
+  const response = await api.get('/api/v1/user/reservations/cancelled');
+  return response.data;
+};
+
+export default {
+  upcoming,
+  pending,
+  history,
+  cancelled,
+};

--- a/src/pages/UserDashboard.tsx
+++ b/src/pages/UserDashboard.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import userReservations from '@/lib/api/userReservations';
+import { Booking } from '@/types';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+
+const UserDashboard: React.FC = () => {
+  const [upcoming, setUpcoming] = useState<Booking[]>([]);
+  const [pending, setPending] = useState<Booking[]>([]);
+  const [history, setHistory] = useState<Booking[]>([]);
+  const [cancelled, setCancelled] = useState<Booking[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [u, p, h, c] = await Promise.all([
+          userReservations.upcoming(),
+          userReservations.pending(),
+          userReservations.history(),
+          userReservations.cancelled(),
+        ]);
+        setUpcoming(u);
+        setPending(p);
+        setHistory(h);
+        setCancelled(c);
+      } catch {
+        setError('Error al cargar reservas');
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      {error && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Tabs defaultValue="upcoming" className="w-full">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="upcoming">Próximas ({upcoming.length})</TabsTrigger>
+          <TabsTrigger value="pending">Pendientes ({pending.length})</TabsTrigger>
+          <TabsTrigger value="history">Historial ({history.length})</TabsTrigger>
+          <TabsTrigger value="cancelled">Canceladas ({cancelled.length})</TabsTrigger>
+        </TabsList>
+        <TabsContent value="upcoming" className="mt-4">
+          {upcoming.length === 0 && <p>No hay reservas próximas.</p>}
+        </TabsContent>
+        <TabsContent value="pending" className="mt-4">
+          {pending.length === 0 && <p>No hay reservas pendientes.</p>}
+        </TabsContent>
+        <TabsContent value="history" className="mt-4">
+          {history.length === 0 && <p>No hay reservas en el historial.</p>}
+        </TabsContent>
+        <TabsContent value="cancelled" className="mt-4">
+          {cancelled.length === 0 && <p>No hay reservas canceladas.</p>}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default UserDashboard;
+


### PR DESCRIPTION
## Summary
- add API helpers for user reservation categories
- show reservation category counts on user dashboard

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb6425ed388320b3b1e2f4efc3f88e